### PR TITLE
Split CI across jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,13 +13,23 @@ jobs:
       matrix:
         include:
           - image: "python:3.7"
-            tox_envs: "py37,py37-speedups"
+            tox_envs: "py37"
           - image: "python:3.8"
-            tox_envs: "py38,py38-speedups"
+            tox_envs: "py38"
           - image: "python:3.9"
-            tox_envs: "py39,py39-speedups,py39-docs"
+            tox_envs: "py39,py39-docs"
           - image: "python:3.10"
-            tox_envs: "py310,py310-speedups"
+            tox_envs: "py310"
+          - image: "python:3.7"
+            tox_envs: "py37-speedups"
+          - image: "python:3.8"
+            tox_envs: "py38-speedups"
+          - image: "python:3.9"
+            tox_envs: "py39-speedups"
+          - image: "python:3.10"
+            tox_envs: "py310-speedups"
+          - image: "python:3.9"
+            tox_envs: "py39-docs"
 
     container:
       image: "${{ matrix.image }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,9 @@ jobs:
   linux-container-tests:
     name: "Linux Container ${{ matrix.image }} ${{ matrix.tox_envs }}"
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         include:
           - image: "python:3.7"


### PR DESCRIPTION
Speedups do not appear to be working correctly on github actions,
splitting them out will make them easier to debug.