### PR TITLE
setup.py: make ordering of requires.txt reproducible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -174,6 +174,9 @@ extras_require['compression'] = set(['brotli'])
 
 extras_require['all'] = set(chain.from_iterable(extras_require.values()))
 
+# sort items to make requires.txt reproducible
+extras_require = { key: sorted(value) for key, value in extras_require.items() }
+
 
 def run_setup(with_cext):
     kwargs = {}


### PR DESCRIPTION
Dependencies are stored in unordered sets, leading to a varying requires.txt
between different builds. Order the entries to make sure that the file is
reproducible bit for bit.