### PR TITLE
Reduce warnings from pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+#filterwarnings =
+#    error

--- a/src/logbook/queues.py
+++ b/src/logbook/queues.py
@@ -256,7 +256,8 @@ class ZeroMQHandler(Handler):
         )
 
     def close(self, linger=-1):
-        self.socket.close(linger)
+        if hasattr(self, "socket"):
+            self.socket.close(linger)
 
     def __del__(self):
         # When the Handler is deleted we must close our socket in a
@@ -285,7 +286,7 @@ class ThreadController(object):
         """Starts the task thread."""
         self.running = True
         self._thread = Thread(target=self._target)
-        self._thread.setDaemon(True)
+        self._thread.daemon = True
         self._thread.start()
 
     def stop(self):
@@ -654,7 +655,7 @@ class TWHThreadController(object):
         """Starts the task thread."""
         self.running = True
         self._thread = Thread(target=self._target)
-        self._thread.setDaemon(True)
+        self._thread.daemon = True
         self._thread.start()
 
     def stop(self):

--- a/src/logbook/ticketing.py
+++ b/src/logbook/ticketing.py
@@ -148,7 +148,6 @@ class SQLAlchemyBackend(BackendBase):
             # Pool size is more custom for out stack
             self.engine = create_engine(
                 engine_or_uri,
-                convert_unicode=True,
                 pool_recycle=360,
                 pool_size=1000,
             )


### PR DESCRIPTION
This fixes up some deprecation warnings, moves the riemann imports to
where they are used (as riemann_client seems unmaintained), and handles
closing the zmq socket more cleanly.