### PR TITLE
Add pytest.ini to manifest and limit tests to py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,11 +1,12 @@
 include CHANGES LICENSE
 recursive-include src *.pyx
-recursive-include tests *
+recursive-include tests *.py
 
 include *.txt
 include *.yml
 include Makefile
 include tox.ini
+include pytest.ini
 
 recursive-include benchmark *.py
 recursive-include docs *.bat


### PR DESCRIPTION
This should mean we're now only including what we need to in the sdist